### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ Current supported input methods
 ## Install
 
 ```shell
-> pip install multlingual_ime
+> pip install multilingual_ime
 ```
 
 ### Run Example
 
 ```shell
 # Install package
-> pip install multlingual_ime
+> pip install multilingual_ime
 # Run cli version of input method
 > python -m multilingual_ime.ime_cli
 ```


### PR DESCRIPTION
This pull request includes a small but important fix to the `README.md` file. The change corrects the spelling of the package name in the installation and example run instructions.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R37): Corrected the spelling of the package name from `multlingual_ime` to `multilingual_ime` in the installation and example run instructions.